### PR TITLE
fix(#664): fresh-claim grace suppresses stale aging after reclaim

### DIFF
--- a/src/team/daemon/automation.rs
+++ b/src/team/daemon/automation.rs
@@ -2497,12 +2497,14 @@ struct InProgressTaskLiveness {
     dirty_worktree: bool,
     output_growth: bool,
     recent_claim_progress: bool,
+    fresh_claim_grace: bool,
     live_progress_type: Option<&'static str>,
 }
 
 impl InProgressTaskLiveness {
     fn has_live_progress(self) -> bool {
-        self.recent_claim_progress
+        self.fresh_claim_grace
+            || self.recent_claim_progress
             || self.output_growth
             || matches!(self.live_progress_type, Some("commit"))
     }
@@ -2593,6 +2595,22 @@ fn task_recent_claim_progress(
     age_secs >= 0 && age_secs < progress_window.as_secs() as i64
 }
 
+fn fresh_claim_immunity_secs(progress_window: Duration) -> u64 {
+    std::cmp::max(60, progress_window.as_secs() / 10)
+}
+
+fn task_in_fresh_claim_grace(
+    task: &crate::task::Task,
+    now: DateTime<Utc>,
+    progress_window: Duration,
+) -> bool {
+    let Some(claimed_at) = task.claimed_at.as_deref().and_then(parse_rfc3339_utc) else {
+        return false;
+    };
+    let age_secs = now.signed_duration_since(claimed_at).num_seconds();
+    age_secs >= 0 && age_secs < fresh_claim_immunity_secs(progress_window) as i64
+}
+
 impl TeamDaemon {
     fn in_progress_task_liveness(
         &self,
@@ -2612,6 +2630,7 @@ impl TeamDaemon {
             dirty_worktree: has_claim_progress_worktree_changes(&work_dir),
             output_growth: current_output_bytes > task.last_output_bytes.unwrap_or(0),
             recent_claim_progress: task_recent_claim_progress(task, now, progress_window),
+            fresh_claim_grace: task_in_fresh_claim_grace(task, now, progress_window),
             live_progress_type: task_claim_progress_type(task, &work_dir, current_output_bytes),
         })
     }
@@ -6102,6 +6121,64 @@ thread 'tmux::tests::split_window_horizontal_creates_new_pane' panicked at src/t
         assert!(events.iter().any(|event| {
             event.event == "task_claim_created" && event.task.as_deref() == Some("42")
         }));
+    }
+
+    #[test]
+    fn fresh_claim_grace_suppresses_stale_aging_with_old_progress_timestamp() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = init_git_repo(&tmp, "fresh-claim-grace");
+        write_board_task_file(
+            &repo,
+            42,
+            "fresh-claim-grace",
+            "in-progress",
+            Some("eng-1"),
+            &[],
+            None,
+        );
+
+        let task_path = board_task_path(&repo, 42);
+        let now = chrono::Utc::now();
+        let old_started = (now - chrono::Duration::hours(8)).to_rfc3339();
+        let stale_progress = (now - chrono::Duration::hours(7)).to_rfc3339();
+        let fresh_claim = now.to_rfc3339();
+        update_task_frontmatter(&task_path, |mapping| {
+            set_optional_string(mapping, "started", Some(&old_started));
+            set_optional_string(mapping, "updated", Some(&old_started));
+            set_optional_string(mapping, "claimed_at", Some(&fresh_claim));
+            set_optional_string(mapping, "last_progress_at", Some(&stale_progress));
+            set_optional_u64(mapping, "last_output_bytes", Some(0));
+        })
+        .unwrap();
+
+        let mut daemon = TestDaemonBuilder::new(repo.as_path())
+            .members(vec![
+                architect_member("architect"),
+                manager_member("manager", Some("architect")),
+                engineer_member("eng-1", Some("manager"), false),
+            ])
+            .workflow_policy(WorkflowPolicy {
+                stale_in_progress_hours: 1,
+                ..WorkflowPolicy::default()
+            })
+            .build();
+        daemon
+            .config
+            .team_config
+            .automation
+            .intervention_cooldown_secs = 300;
+
+        daemon.maybe_emit_task_aging_alerts().unwrap();
+
+        let events =
+            crate::team::events::read_events(&crate::team::team_events_path(&repo)).unwrap();
+        assert!(
+            !events.iter().any(|event| {
+                matches!(event.event.as_str(), "task_stale" | "task_escalated")
+                    && event.task.as_deref() == Some("42")
+            }),
+            "fresh claims should suppress stale aging even when last_progress_at is old"
+        );
     }
 
     #[test]

--- a/src/team/task_cmd.rs
+++ b/src/team/task_cmd.rs
@@ -71,10 +71,25 @@ pub(crate) fn assign_task_owners(
     let task_path = find_task_path(board_dir, task_id)?;
     update_task_frontmatter(&task_path, |mapping| {
         if let Some(owner) = exec_owner {
-            set_optional_string(mapping, "claimed_by", normalize_optional(owner));
-            if normalize_optional(owner).is_some() {
+            let normalized_owner = normalize_optional(owner);
+            set_optional_string(mapping, "claimed_by", normalized_owner);
+            if normalized_owner.is_some() {
                 let now = Utc::now();
                 set_optional_string(mapping, "claimed_at", Some(&now.to_rfc3339()));
+                set_optional_string(mapping, "last_progress_at", Some(&now.to_rfc3339()));
+                set_optional_u64(mapping, "claim_ttl_secs", None);
+                set_optional_string(mapping, "claim_expires_at", None);
+                set_optional_string(mapping, "claim_warning_sent_at", None);
+                set_optional_u32(mapping, "claim_extensions", None);
+                set_optional_u64(mapping, "last_output_bytes", None);
+            } else {
+                set_optional_string(mapping, "claimed_at", None);
+                set_optional_string(mapping, "last_progress_at", None);
+                set_optional_u64(mapping, "claim_ttl_secs", None);
+                set_optional_string(mapping, "claim_expires_at", None);
+                set_optional_string(mapping, "claim_warning_sent_at", None);
+                set_optional_u32(mapping, "claim_extensions", None);
+                set_optional_u64(mapping, "last_output_bytes", None);
             }
         }
         if let Some(owner) = review_owner {
@@ -786,6 +801,30 @@ mod tests {
         let task = Task::from_file(&task_path).unwrap();
         assert_eq!(task.claimed_by.as_deref(), Some("eng-1-2"));
         assert_eq!(task.review_owner.as_deref(), Some("manager-1"));
+    }
+
+    #[test]
+    fn assign_resets_claim_progress_tracking_for_execution_owner() {
+        let tmp = tempfile::tempdir().unwrap();
+        let board_dir = tmp.path();
+        let task_path = write_task_file(board_dir, 17, "in-progress");
+        std::fs::write(
+            &task_path,
+            "---\nid: 17\ntitle: Task 17\nstatus: in-progress\npriority: high\nclaimed_by: eng-9\nclaimed_at: 2026-04-14T14:00:00Z\nclaim_ttl_secs: 900\nclaim_expires_at: 2026-04-14T14:15:00Z\nlast_progress_at: 2026-04-14T14:00:00Z\nclaim_warning_sent_at: 2026-04-14T14:10:00Z\nclaim_extensions: 2\nlast_output_bytes: 512\nclass: standard\n---\n\nTask body.\n",
+        )
+        .unwrap();
+
+        cmd_assign(board_dir, 17, Some("eng-1-2"), None).unwrap();
+
+        let task = Task::from_file(&task_path).unwrap();
+        assert_eq!(task.claimed_by.as_deref(), Some("eng-1-2"));
+        assert!(task.claimed_at.is_some());
+        assert_eq!(task.claim_ttl_secs, None);
+        assert_eq!(task.claim_expires_at, None);
+        assert!(task.last_progress_at.is_some());
+        assert_eq!(task.claim_warning_sent_at, None);
+        assert_eq!(task.claim_extensions, None);
+        assert_eq!(task.last_output_bytes, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds a fresh-claim grace window to `InProgressTaskLiveness` so that a task reclaimed from a quota-blocked engineer is not immediately flagged `task_stale` / `task_escalated` based on the prior claim's stale `last_progress_at`.
- `batty assign` now resets claim-progress tracking (claim_ttl_secs, claim_expires_at, claim_warning_sent_at, claim_extensions, last_output_bytes) and stamps a fresh `last_progress_at` so downstream liveness checks start from the reclaim moment.

## Test plan
- [x] `cargo test --lib --release fresh_claim_grace_suppresses_stale_aging_with_old_progress_timestamp`
- [x] `cargo test --lib --release assign_resets_claim_progress_tracking_for_execution_owner`

## Related
Partially addresses #664. The broader retry_at / health-gating cascade (dispatch selection, stall-timer reclaim, stuck-task escalator, health::checks flap) is tracked in #674.